### PR TITLE
Add default dimensions for SVG icon

### DIFF
--- a/templates/images/icon_xbbb.svg
+++ b/templates/images/icon_xbbb.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 16.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	  viewBox="0 0 226.771 226.771" enable-background="new 0 0 226.771 226.771"
+	  viewBox="0 0 226.771 226.771" enable-background="new 0 0 226.771 226.771" width="32" height="32"
 	 xml:space="preserve">
 <image overflow="visible" width="220" height="276" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANwAAAEUCAYAAABAlljsAAAgAElEQVR42uy9edRl11Uf+Nv3jd/8
 1TzPUskllWXJlmRblm1ZNrIQIAsnGMc2YGjaSbtNs2IgEIb0Sno5DhA6nWZ107CaXk0TxhBCd4dO


### PR DESCRIPTION
This PR contains changes regarding the default dimensions of the SVG icon used for BBB ILIAS repository objects.

Not all ILIAS views limit the icon dimesions by using CSS, so the BBB icon is extremely large in particular views (e.g. if a user wants to assign a BBB object as Session material). Therefore I explicitly set a `width="32"` and `height="32"` according to the ILIAS object icon recommendations.