### PR TITLE
follow redirects

### DIFF
--- a/classes/bbb-api/bbb_api.php
+++ b/classes/bbb-api/bbb_api.php
@@ -34,6 +34,7 @@ function bbb_wrap_simplexml_load_file($url){
 		curl_setopt( $ch, CURLOPT_SSL_VERIFYPEER, false);	
 		curl_setopt( $ch, CURLOPT_URL, $url );
 		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, 1 );
+		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
 		curl_setopt( $ch, CURLOPT_CONNECTTIMEOUT, $timeout);
 		
 		//Add Proxy


### PR DESCRIPTION
This change configures CURL to follow redirects.
Newer versions of the BBB php api client does the same.

https://github.com/bigbluebutton/bigbluebutton-api-php/commit/236df4c4b377ff2a7c72d0a28a00e521499f9a5d