### PR TITLE
Fix SQL syntax error on plugin config update

### DIFF
--- a/classes/class.ilBigBlueButtonConfigGUI.php
+++ b/classes/class.ilBigBlueButtonConfigGUI.php
@@ -154,7 +154,7 @@ class ilBigBlueButtonConfigGUI extends ilPluginConfigGUI
 				" svrpublicurl = ".$ilDB->quote($setPublicURL, "text").",".
 				" svrprivateurl = ".$ilDB->quote($setPublicURL, "text").",".
 				" svrsalt = ".$ilDB->quote($setSalt, "text"). ",".
-				" choose_recording = ".$ilDB->quote($choose_recording, "integer").",".
+				" choose_recording = ".$ilDB->quote($choose_recording, "integer").
 				" WHERE id = ".$ilDB->quote(1, "integer")
 				);
 			}


### PR DESCRIPTION
Comma is not allowed before WHERE clause in MySQL.

Fixes
ERROR: ilErrorHandling::{closure}:50 10000 An undefined Database Exception occured.
SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL
syntax; check the manual that corresponds to your MariaDB server version for the right
syntax to use near
'WHERE id = 1' at line 1 QUERY: UPDATE rep_robj_xbbb_conf  SET 
svrpublicurl = 'https://blindsidenetworks-curates-bbb.com/',
svrprivateurl = 'https://blindsidenetworks-curates-bbb.com/',
svrsalt = 'secret_salt',
choose_recording = 1,
WHERE id = 1
in /var/www/ilias/Services/Database/classes/PDO/class.ilDBPdo.php:775