### PR TITLE
Add option to controll Learning Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ On your ILIAS Server:
         - E.g:  https://my.bbb-server.com:9003/bigbluebutton
         
     - BBB security salt
+    - Enable global recording option
+    - Enable global Learning Dashboard
 - finally you can create "Bigbluebutton" Virtual Classrooms as regular repository object
 **Note:** If the server is not reachable, during configuration a message will be displayed. After correcting the error, make sure to press the save button twice.
 

--- a/classes/bbb-api/bbb_api.php
+++ b/classes/bbb-api/bbb_api.php
@@ -156,11 +156,11 @@ class BigBlueButton {
 	*
 	*@return The url to join the meeting
 	*/
-	public static function createMeetingURL($name, $meetingID, $attendeePW, $moderatorPW, $welcome, $logoutURL, $SALT, $URL, $record = false ) {
+	public static function createMeetingURL($name, $meetingID, $attendeePW, $moderatorPW, $welcome, $logoutURL, $SALT, $URL, $record = false, $enable_learningdashboard=false) {
 		$url_create = $URL."api/create?";
 		$voiceBridge = 70000 + rand(0, 9999);
 
-		$params = 'name='.urlencode($name).'&meetingID='.urlencode($meetingID).'&attendeePW='.urlencode($attendeePW).'&moderatorPW='.urlencode($moderatorPW).'&voiceBridge='.$voiceBridge.'&logoutURL='.urlencode($logoutURL);
+		$params = 'name='.urlencode($name).'&meetingID='.urlencode($meetingID).'&attendeePW='.urlencode($attendeePW).'&moderatorPW='.urlencode($moderatorPW).'&voiceBridge='.$voiceBridge.'&logoutURL='.urlencode($logoutURL).'&learningDashboardEnabled='.urlencode($enable_learningdashboard);
 
                 if($record){
                     
@@ -350,9 +350,9 @@ class BigBlueButton {
 	*	- If failed it returns an array containing a returncode, messageKey, message. 
 	*	- If success it returns an array containing a returncode, messageKey, message, meetingID, attendeePW, moderatorPW, hasBeenForciblyEnded.
 	*/
-	public static function createMeetingArray( $username, $meetingID, $welcomeString, $mPW, $aPW, $SALT, $URL, $logoutURL, $record=false) {
+	public static function createMeetingArray( $username, $meetingID, $welcomeString, $mPW, $aPW, $SALT, $URL, $logoutURL, $record=false, $enable_learningdashboard=false) {
 
-		$xml = bbb_wrap_simplexml_load_file( BigBlueButton::createMeetingURL($username, $meetingID, $aPW, $mPW, $welcomeString, $logoutURL, $SALT, $URL, $record ) );
+		$xml = bbb_wrap_simplexml_load_file( BigBlueButton::createMeetingURL($username, $meetingID, $aPW, $mPW, $welcomeString, $logoutURL, $SALT, $URL, $record, $enable_learningdashboard) );
 
 		if( $xml ) {
 			if($xml->meetingID) return array('returncode' => $xml->returncode, 'message' => $xml->message, 'messageKey' => $xml->messageKey, 'meetingID' => $xml->meetingID, 'attendeePW' => $xml->attendeePW, 'moderatorPW' => $xml->moderatorPW, 'hasBeenForciblyEnded' => $xml->hasBeenForciblyEnded );

--- a/classes/class.ilBigBlueButtonConfigGUI.php
+++ b/classes/class.ilBigBlueButtonConfigGUI.php
@@ -58,6 +58,7 @@ class ilBigBlueButtonConfigGUI extends ilPluginConfigGUI
 	        $values["svrprivateurl"] = $record["svrprivateurl"];
 			$values["svrsalt"] = $record["svrsalt"];
 			$values["choose_recording"] = $record["choose_recording"];
+			$values["enable_learningdashboard"] = $record["enable_learningdashboard"];
 		}
 
 		
@@ -106,6 +107,12 @@ class ilBigBlueButtonConfigGUI extends ilPluginConfigGUI
 		$choose_recording->setChecked((int) $values['choose_recording']);
 		$form->addItem($choose_recording);
 		
+		//Learning Dashboard configuration
+		$enable_learningdashboard = new ilCheckboxInputGUI($pl->txt("enable_learningdashboard"), "enable_learningdashboard");
+		$enable_learningdashboard->setRequired(false);
+		$enable_learningdashboard->setInfo($pl->txt("enable_learningdashboard_info"));
+		$enable_learningdashboard->setChecked((int) $values['enable_learningdashboard']);
+		$form->addItem($enable_learningdashboard);
 	
 		$form->addCommandButton("save", $lng->txt("save"));
 	                
@@ -133,6 +140,7 @@ class ilBigBlueButtonConfigGUI extends ilPluginConfigGUI
 			$setPrivateURL = $this->checkUrl($form->getInput("frmprivateurl"));
 			$setSalt= $form->getInput("frmsalt");
 			$choose_recording = (int) $form->getInput("choose_recording");
+			$enable_learningdashboard = (int) $form->getInput("enable_learningdashboard");
 			
 			// check if data exisits decide to update or insert
 			$result = $ilDB->query("SELECT * FROM rep_robj_xbbb_conf");
@@ -141,20 +149,22 @@ class ilBigBlueButtonConfigGUI extends ilPluginConfigGUI
 
 
 				$ilDB->manipulate("INSERT INTO rep_robj_xbbb_conf ".
-				"(id, svrpublicurl , svrprivateurl, svrsalt, choose_recording) VALUES (".
+				"(id, svrpublicurl , svrprivateurl, svrsalt, choose_recording, enable_learningdashboard) VALUES (".
 				$ilDB->quote(1, "integer").",". // id
 				$ilDB->quote($setPublicURL, "text").",". //public url
 				$ilDB->quote($setPrivateURL, "text").",". //private url
 
 				$ilDB->quote($setSalt, "text").",". //salt
-				$ilDB->quote($choose_recording, "integer").
+				$ilDB->quote($choose_recording, "integer").",".
+				$ilDB->quote($enable_learningdashboard, "integer").
 				")");
 			}else{
 				$ilDB->manipulate($up = "UPDATE rep_robj_xbbb_conf  SET ".
 				" svrpublicurl = ".$ilDB->quote($setPublicURL, "text").",".
 				" svrprivateurl = ".$ilDB->quote($setPublicURL, "text").",".
 				" svrsalt = ".$ilDB->quote($setSalt, "text"). ",".
-				" choose_recording = ".$ilDB->quote($choose_recording, "integer").
+				" choose_recording = ".$ilDB->quote($choose_recording, "integer"). ",".
+				" enable_learningdashboard = ".$ilDB->quote($enable_learningdashboard, "integer").
 				" WHERE id = ".$ilDB->quote(1, "integer")
 				);
 			}

--- a/classes/class.ilBigBlueButtonProtocol.php
+++ b/classes/class.ilBigBlueButtonProtocol.php
@@ -51,7 +51,7 @@ class ilBigBlueButtonProtocol
 	
 	
 	
-	function createMeeting($object, $record = false){
+	function createMeeting($object, $record = false, $enable_learningdashboard = false){
 		global $DIC; /** @var Container $DIC */
 		$dic=$DIC;		
 		
@@ -87,7 +87,7 @@ class ilBigBlueButtonProtocol
 		$logoutURL = ilLink::_getLink($object->getRefId());
 		
 		
-		$response=BigBlueButton::createMeetingArray($meetingTitle, $meetingID, $welcomeString, $mPW, $aPW, $SALT, $srvURL, $logoutURL, $record );
+		$response=BigBlueButton::createMeetingArray($meetingTitle, $meetingID, $welcomeString, $mPW, $aPW, $SALT, $srvURL, $logoutURL, $record, $enable_learningdashboard);
 		
 		return $response;
 		

--- a/classes/class.ilObjBigBlueButtonGUI.php
+++ b/classes/class.ilObjBigBlueButtonGUI.php
@@ -259,6 +259,7 @@ class ilObjBigBlueButtonGUI extends ilObjectPluginGUI
 			$svrPublicURL = $record["svrpublicurl"];
 			$svrPublicPort = $record["svrpublicport"];
 			$values["choose_recording"] = $record["choose_recording"];
+			$values["enable_learningdashboard"] = $record["enable_learningdashboard"];
 		}
 
 
@@ -348,6 +349,11 @@ class ilObjBigBlueButtonGUI extends ilObjectPluginGUI
 				$my_tpl->setVariable("CHOOSE_RECORDING_VISIBLE", "visible");
 			}else{
 				$my_tpl->setVariable("CHOOSE_RECORDING_VISIBLE", "hidden");
+			}
+			if ($values["enable_learningdashboard"]){
+				$my_tpl->setVariable("ENABLE_LEARNINGDASHBOARD_VISIBLE", "visible");
+			}else{
+				$my_tpl->setVariable("ENABLE_LEARNINGDASHBOARD_VISIBLE", "hidden");
 			}
 			$my_tpl->setVariable("checkbox_record_meeting", $this->txt("checkbox_record_meeting"));
 			$my_tpl->setVariable("hasMeetingRecordings", $recordcount > 0?"true":"false");

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -60,3 +60,6 @@ meetingRecordedMessage#:#Die aktuelle Sitzung wird aufgezeichnet!
 saving_invoked#:#Eintrag gespeichert
 choose_recording#:#Aufnahmen erlauben: Auswahlmöglichkeit
 choose_recording_info#:#Aktivieren Sie diese Option, wenn Benutzer mit Schreibrechten unter Einstellungen die Auswahl 'Aufnahmen erlauben' haben sollen. Da bei Bekanntwerden der URL zur Aufnahme eine Verbreitung an nicht vorgesehene Personen gegeben ist, sollte diese Option in den meisten Fällen nicht aktiviert sein.
+checkbox_enable_learningdashboard#:#Aktivitäten-Übersicht aktivieren
+enable_learningdashboard#:#Aktivitäten-Übersicht aktivieren
+enable_learningdashboard_info#:#Wenn diese Funktion aktiviert ist, können Moderatoren eine Zusammenfassung der Aktivitäten der Teilnehmenden sehen. Bitte beachten Sie die geltenden Datenschutzbestimmungen. (Verfügbar ab Version 2.4)

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -59,3 +59,6 @@ status#:#status
 saving_invoked#:#saved
 choose_recording#:#Allow recordings globally
 choose_recording_info#:#Activate this option if you want users with write permissions to select 'Allow capturing' under Settings. Since the URL for the recording is known to be distributed to unintended persons, this option should not be activated in most cases.
+checkbox_enable_learningdashboard#:#Enable Learning Dashboard
+enable_learningdashboard#:#Enable Learning Dashboard
+enable_learningdashboard_info#:#When this option is enabled BigBlueButton generates a Dashboard where moderators can view a summary of the activities of the meeting. Please review your actual privacy policy. (Verfügbar ab Version 2.4)

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -60,3 +60,6 @@ saving_invoked#:#Guardado
 offline#:#Desactivado
 choose_recording#:#Allow recordings globally
 choose_recording_info#:#Activate this option if you want users with write permissions to select 'Allow capturing' under Settings. Since the URL for the recording is known to be distributed to unintended persons, this option should not be activated in most cases.
+checkbox_enable_learningdashboard#:#Habilitar el panel de aprendizaje
+enable_learningdashboard#:#Habilitar el panel de aprendizaje
+enable_learningdashboard_info#:#Cuando esta opción está habilitada, BigBlueButton genera un Tablero donde los moderadores pueden ver un resumen de las actividades de la reunión. Revise su política de privacidad actual. (Version 2.4)

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -55,3 +55,6 @@ meetingRecordedMessage#:#La sessione corrente viene registrato
 saving_invoked#:#saved
 choose_recording#:#Allow recordings globally
 choose_recording_info#:#Activate this option if you want users with write permissions to select 'Allow capturing' under Settings. Since the URL for the recording is known to be distributed to unintended persons, this option should not be activated in most cases.
+checkbox_enable_learningdashboard#:#Enable Learning Dashboard
+enable_learningdashboard#:#Enable Learning Dashboard
+enable_learningdashboard_info#:#When this option is enabled BigBlueButton generates a Dashboard where moderators can view a summary of the activities of the meeting. Please review your actual privacy policy. (Version 2.4)

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -58,3 +58,6 @@ status#:#status
 saving_invoked#:#opgeslagen
 choose_recording#:#Allow recordings globally
 choose_recording_info#:#Activate this option if you want users with write permissions to select 'Allow capturing' under Settings. Since the URL for the recording is known to be distributed to unintended persons, this option should not be activated in most cases.
+checkbox_enable_learningdashboard#:#Enable Learning Dashboard
+enable_learningdashboard#:#Enable Learning Dashboard
+enable_learningdashboard_info#:#When this option is enabled BigBlueButton generates a Dashboard where moderators can view a summary of the activities of the meeting. Please review your actual privacy policy. (Version 2.4)

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -58,3 +58,6 @@ status#:#status
 saving_invoked#:#salvo
 choose_recording#:#Allow recordings globally
 choose_recording_info#:#Activate this option if you want users with write permissions to select 'Allow capturing' under Settings. Since the URL for the recording is known to be distributed to unintended persons, this option should not be activated in most cases.
+checkbox_enable_learningdashboard#:#Enable Learning Dashboard
+enable_learningdashboard#:#Enable Learning Dashboard
+enable_learningdashboard_info#:#When this option is enabled BigBlueButton generates a Dashboard where moderators can view a summary of the activities of the meeting. Please review your actual privacy policy. (Version 2.4)

--- a/plugin.php
+++ b/plugin.php
@@ -9,7 +9,7 @@ $version = "1.0.15";
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin
 $ilias_min_version = "4.0.0";
-$ilias_max_version = "6.99";
+$ilias_max_version = "7.99";
  
 // optional, but useful: Add one or more responsible persons and a contact email
 $responsible = "Minervis GmbH";

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -181,3 +181,14 @@ if (!$ilDB->tableColumnExists("rep_robj_xbbb_conf", "choose_recording")){
 	));
 }
 ?>
+<#4>
+<?php
+if (!$ilDB->tableColumnExists("rep_robj_xbbb_conf", "enable_learningdashboard")){
+	$ilDB->addTableColumn('rep_robj_xbbb_conf', 'enable_learningdashboard', array(
+		'type' => 'integer',
+		'length' => 1,
+		'notnull' => true,
+		'default' => 0
+	));
+}
+?>

--- a/templates/tpl.BigBlueButtonModeratorClient.html
+++ b/templates/tpl.BigBlueButtonModeratorClient.html
@@ -71,6 +71,8 @@
 </div>
 <p class="choose_recording" style='visibility: {CHOOSE_RECORDING_VISIBLE};'>
 <input type="checkbox" id="recordmeeting_visible" /><span id="recordmeeting_label">{checkbox_record_meeting}</span>
+<p class="enable_learningdashboard" style='visibility: {ENABLE_LEARNINGDASHBOARD_VISIBLE};'>
+<input type="checkbox" id="recordmeeting_visible" /><span id="recordmeeting_label">{checkbox_enable_learningdashboard}</span>
 <p>
 <div id="endClassDiv">
 {classRunning} <a id="endClassLink" href="#" class="btn btn-default">{endClass}</a><br/><i> {endClassComment}</i>


### PR DESCRIPTION
In BBB version 2.4 (release soon planned) a new "Learning Dashboard" with all activities by the Attendees will added in BBB. In germandy it's critiacal with actual law an privacy policies. 

With this PR i add an admin-setting to disable the learning dashboard. If admin enable the function, moderators can choosen while create a new room, if they want to enable the learning dashboard for the session.