### PR TITLE
fix compatible warning

### DIFF
--- a/classes/class.ilBigBlueButtonProtocol.php
+++ b/classes/class.ilBigBlueButtonProtocol.php
@@ -225,7 +225,7 @@ class ilBigBlueButtonProtocol
 
 class BBB extends \BigBlueButton\BigBlueButton
 {
-    public function __construct($securitySecret, $baseUrl)
+    public function __construct($securitySecret=null, $baseUrl=null)
     {
         parent::__construct();
         $this->securitySecret = $securitySecret;

--- a/classes/class.ilBigBlueButtonProtocol.php
+++ b/classes/class.ilBigBlueButtonProtocol.php
@@ -53,7 +53,7 @@ class ilBigBlueButtonProtocol
     public function getInviteUrl($title = "Guest")
     {
         $link = ILIAS_HTTP_PATH . "/" . substr(dirname(__FILE__), strpos(dirname(__FILE__), 'Customizing'), -8) . '/guest.php?';
-        $query = "ref_id=" . $this->object->getRefId() . "&client=" . CLIENT_ID;
+        $query = "ref_id=" . $this->object->getRefId() . "&client_id=" . CLIENT_ID;
         return $link . $query;
     }
 

--- a/guest.php
+++ b/guest.php
@@ -10,7 +10,13 @@ use BigBlueButton\Responses\GetRecordingsResponse;
 use BigBlueButton\Parameters\DeleteRecordingsParameters;
 use ILIAS\DI\Container;
 
-chdir("../../../../../../../");
+$directory = strstr($_SERVER['SCRIPT_FILENAME'], 'Customizing', true);
+if(empty($directory))
+{
+	$directory = getcwd();
+}
+chdir($directory);
+
 require_once('./Services/Context/classes/class.ilContext.php');
 require_once("./Services/Init/classes/class.ilInitialisation.php");
 require_once("./Services/Utilities/classes/class.ilUtil.php");
@@ -450,7 +456,7 @@ class GuestLink
 
     private function __construct()
     {
-        $this->client = filter_var($_GET['client'], FILTER_SANITIZE_STRING);
+        $this->client = filter_var($_GET['client_id'], FILTER_SANITIZE_STRING);
         $this->refId = filter_var($_GET['ref_id'], FILTER_SANITIZE_NUMBER_INT);
         ilInitialisationGuest::initIlias($this->client);
         global $DIC; /** @var Container $DIC */

--- a/guest.php
+++ b/guest.php
@@ -2,6 +2,7 @@
 ini_set('display_errors', 1);
 ini_set('error_reporting', 5);
 
+use Exception;
 use BigBlueButton\Core\Record;
 use BigBlueButton\Parameters\CreateMeetingParameters;
 use BigBlueButton\Responses\GetMeetingsResponse;
@@ -37,7 +38,12 @@ class ilInitialisationGuest extends ilInitialisation
         return $http_path;
     }
 
-    public static function initIlias($client_id, $client_token = '') {
+    public static function initIlias($client_id=null, $client_token=null) {
+	    
+	if(empty($client_id))
+	{
+		throw new Exception("There has been an error. Try it again.");
+	}
         define ("CLIENT_ID", $client_id);
         define('IL_COOKIE_HTTPONLY', true); // Default Value
         define('IL_COOKIE_EXPIRE', 0);

--- a/guest.php
+++ b/guest.php
@@ -1,8 +1,8 @@
 <?php
-ini_set('display_errors', 1);
+// enable display errors only on dev systems
+//ini_set('display_errors', 1);
 ini_set('error_reporting', 5);
 
-use Exception;
 use BigBlueButton\Core\Record;
 use BigBlueButton\Parameters\CreateMeetingParameters;
 use BigBlueButton\Responses\GetMeetingsResponse;
@@ -42,7 +42,7 @@ class ilInitialisationGuest extends ilInitialisation
 	    
 	if(empty($client_id))
 	{
-		throw new Exception("There has been an error. Try it again.");
+		throw new \Exception("There has been an error. Try it again.");
 	}
         define ("CLIENT_ID", $client_id);
         define('IL_COOKIE_HTTPONLY', true); // Default Value


### PR DESCRIPTION
This PR fixes #36 

The arguments while ilInitialisation are only in the subclass required, but not in the extended class. So the arguments must been NULL as default and an additional check if the required arguments are passed.