### PR TITLE
Fix reachability check

### DIFF
--- a/classes/class.ilBigBlueButtonConfigGUI.php
+++ b/classes/class.ilBigBlueButtonConfigGUI.php
@@ -69,7 +69,7 @@ class ilBigBlueButtonConfigGUI extends ilPluginConfigGUI
         if ($values["svrpublicurl"] != '' && $values["svrprivateurl"] != '' && $values["svrsalt"] != '') {
             $server_reachable=$this->isServerReachable($values["svrpublicurl"], $values["svrsalt"]);
             if (!$server_reachable) {
-                ilUtil::sendFailure("server not reachable", true);
+                ilUtil::sendFailure($pl->txt("sever_not_reachable"), true);
             }
         }
 

--- a/classes/class.ilBigBlueButtonConfigGUI.php
+++ b/classes/class.ilBigBlueButtonConfigGUI.php
@@ -191,12 +191,11 @@ class ilBigBlueButtonConfigGUI extends ilPluginConfigGUI
         include_once("./Customizing/global/plugins/Services/Repository/RepositoryObject/BigBlueButton/classes/class.ilBigBlueButtonProtocol.php");
         $bbb_helper=new BBB($salt,$url);
         try{
-            $bbb_helper->getApiVersion();
+            $apiVersion = $bbb_helper->getApiVersion();
+	    return $apiVersion->success();
         }catch (Exception $e) {
             return false;
         }
-        return true;
-
     }
 
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -60,6 +60,7 @@ Headline_Recordings#:#bisherige Aufnahmen
 checkbox_record_meeting#:#Sitzung aufzeichnen
 meetingRecordedMessage#:#Die aktuelle Sitzung wird aufgezeichnet!
 saving_invoked#:#Eintrag gespeichert
+sever_not_reachable#:#Bei dem Versuch den Server zu erreichen ist ein Fehler aufgetreten. Bitte überprüfe die eingegebene URL sowie den Salt auf Gültigkeit.
 choose_recording#:#Aufnahmen erlauben: Auswahlmöglichkeit
 choose_recording_info#:#Aktivieren Sie diese Option, wenn Benutzer mit Schreibrechten unter Einstellungen die Auswahl 'Aufnahmen erlauben' haben sollen. Da bei Bekanntwerden der URL zur Aufnahme eine Verbreitung an nicht vorgesehene Personen gegeben ist, sollte diese Option in den meisten Fällen nicht aktiviert sein.
 configurations#:# Konfiguration

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -58,6 +58,7 @@ edit#:#Edit
 title#:#title
 status#:#status
 saving_invoked#:#saved
+sever_not_reachable#:#An error occurred while trying to reach the server. Please check the entered URL and salt for validity.
 choose_recording#:#Allow recordings globally
 choose_recording_info#:#Activate this option if you want users with write permissions to select 'Allow capturing' under Settings. Since the URL for the recording is known to be distributed to unintended persons, this option should not be activated in most cases.
 configurations#:# Konfiguration

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -58,6 +58,7 @@ edit#:#Editar
 title#:#Título
 status#:#Estado
 saving_invoked#:#Guardado
+sever_not_reachable#:#Ocurrió un error al intentar llegar al servidor. Verifique la URL ingresada y la sal para ver si son válidas.
 offline#:#Desactivado
 choose_recording#:#Allow recordings globally
 choose_recording_info#:#Activate this option if you want users with write permissions to select 'Allow capturing' under Settings. Since the URL for the recording is known to be distributed to unintended persons, this option should not be activated in most cases.

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -58,6 +58,7 @@ edit#:#Editer
 title#:#Titre
 status#:#Etat
 saving_invoked#:#Sauvegardé
+sever_not_reachable#:#Une erreur s'est produite lors de la tentative d'accès au serveur. Veuillez vérifier la validité de l'URL et du sel saisis.
 choose_recording#:#Autoriser les enregistrements
 choose_recording_info#:#Activer cette option si vous voulez donner la possibiliter d'enregistrer les classes.
 configurations#:# Configuration

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -53,6 +53,7 @@ Headline_Recordings#:#registrazioni precedenti
 checkbox_record_meeting#:#sessione di registrazione
 meetingRecordedMessage#:#La sessione corrente viene registrato
 saving_invoked#:#saved
+sever_not_reachable#:#Si è verificato un errore durante il tentativo di raggiungere il server. Si prega di verificare la validità dell'URL inserito e del sale.
 choose_recording#:#Allow recordings globally
 choose_recording_info#:#Activate this option if you want users with write permissions to select 'Allow capturing' under Settings. Since the URL for the recording is known to be distributed to unintended persons, this option should not be activated in most cases.
 configurations#:# Konfiguration

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -56,6 +56,7 @@ edit#:#Bewerken
 title#:#titel
 status#:#status
 saving_invoked#:#opgeslagen
+sever_not_reachable#:#Er is een fout opgetreden bij het bereiken van de server. Controleer de ingevoerde URL en salt op geldigheid.
 choose_recording#:#Allow recordings globally
 choose_recording_info#:#Activate this option if you want users with write permissions to select 'Allow capturing' under Settings. Since the URL for the recording is known to be distributed to unintended persons, this option should not be activated in most cases.
 configurations#:# Konfiguration

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -56,6 +56,7 @@ edit#:#Editar
 title#:#titulo
 status#:#status
 saving_invoked#:#salvo
+sever_not_reachable#:#Ocorreu um erro ao tentar acessar o servidor. Por favor, verifique a validade do URL inserido e do salt.
 choose_recording#:#Allow recordings globally
 choose_recording_info#:#Activate this option if you want users with write permissions to select 'Allow capturing' under Settings. Since the URL for the recording is known to be distributed to unintended persons, this option should not be activated in most cases.
 configurations#:# Konfiguration


### PR DESCRIPTION
Currently, the reachibility check fails only if an exception is thrown. If the server isn't reachable, the api responses "false" and no exception. THis PR fixes the bug.