### PR TITLE
session/license management

### DIFF
--- a/classes/class.ilBigBlueButtonConfigGUI.php
+++ b/classes/class.ilBigBlueButtonConfigGUI.php
@@ -61,6 +61,10 @@ class ilBigBlueButtonConfigGUI extends ilPluginConfigGUI
             $values["svrsalt"] = $record["svrsalt"];
             $values["choose_recording"] = $record["choose_recording"];
             $values["guest_global_choose"] = $record["guestglobalchoose"];
+            $values["sess_enable_max_concurrent"] = $record["sess_enable_max_concurrent"];
+            $values["enable_userlimit"] = $record["enable_userlimit"];
+            $values["sess_max_concurrent"] = $record["sess_max_concurrent"];
+            $values["sess_msg_concurrent"] = $record["sess_msg_concurrent"];
         }
 
 
@@ -109,6 +113,39 @@ class ilBigBlueButtonConfigGUI extends ilPluginConfigGUI
         $choose_recording->setChecked((int) $values['guest_global_choose']);
         $form->addItem($choose_recording);
 
+        //Session management
+        $sess_header = new ilFormSectionHeaderGUI();
+        $sess_header->setTitle($pl->txt("sess_management_header"));
+
+        $form->addItem($sess_header);
+        $sess = new ilCheckboxInputGUI($pl->txt("sess_max_concurrent_sessions"), "sess_enable_max_concurrent");
+        $sess->setValue(1);
+        $sess->setChecked((int) $values["sess_enable_max_concurrent"]);
+        $sess->setInfo("");
+
+        $sess_userlimit = new ilCheckboxInputGUI($pl->txt("sess_enable_userlimit"), "enable_userlimit");
+        $sess_userlimit->setValue(1);
+        $sess_userlimit->setChecked((int) $values["enable_userlimit"]);
+        //$sess_userlimit->setInfo($pl->txt("sess_userlimit_info"));
+        $sess->addSubItem($sess_userlimit);
+
+        
+        $sess_concurrent_sessions = new ilNumberInputGUI($pl->txt("sess_max_concurrent_sessions"), "sess_max_concurrent");
+        $sess_concurrent_sessions->setSize(30);
+        $sess_concurrent_sessions->setRequired(false);
+        $sess_concurrent_sessions->setValue($values["sess_max_concurrent"]);
+        $sess_concurrent_sessions->setInfo("");
+
+        $sess->addSubItem($sess_concurrent_sessions);
+
+        $sess_msg_concurrent = new ilTextAreaInputGUI($pl->txt("sess_msg_concurrent_limit_title"), "sess_msg_concurrent");
+        $sess_msg_concurrent->setInfo($pl->txt("sess_msg_concurrent_limit_info"));
+        $sess_msg_concurrent->setValue($values["sess_msg_concurrent"] ? $values["sess_msg_concurrent"]: $pl->txt("sess_msg_concurrent_limit"));
+        //$sess_msg_concurrent->setSize(256);
+
+        $sess->addSubItem($sess_msg_concurrent);
+
+        $form->addItem($sess);
 
         $form->addCommandButton("save", $lng->txt("save"));
 
@@ -133,6 +170,10 @@ class ilBigBlueButtonConfigGUI extends ilPluginConfigGUI
             $setSalt= $form->getInput("frmsalt");
             $choose_recording = (int) $form->getInput("choose_recording");
             $guest_global_choose = (int) $form->getInput("guest_global_choose");
+            $sess_enable_max_concurrent = (int) $form->getInput("sess_enable_max_concurrent");
+            $enable_userlimit = (int) $form->getInput("enable_userlimit");
+            $sess_max_concurrent = (int) $form->getInput("sess_max_concurrent");
+            $sess_msg_concurrent = $form->getInput("sess_msg_concurrent");
 
             // check if data exisits decide to update or insert
             $result = $ilDB->query("SELECT * FROM rep_robj_xbbb_conf");
@@ -144,7 +185,11 @@ class ilBigBlueButtonConfigGUI extends ilPluginConfigGUI
                 $ilDB->quote($setPublicURL, "text").",". //public url
                 $ilDB->quote($setSalt, "text").",". //salt
                 $ilDB->quote($choose_recording, "integer").",".
-                $ilDB->quote($guest_global_choose, "integer").
+                $ilDB->quote($guest_global_choose, "integer"). ", ".
+                $ilDB->quote($sess_enable_max_concurrent, "integer"). ", ".
+                $ilDB->quote($enable_userlimit, "integer"). ", ".
+                $ilDB->quote($sess_max_concurrent, "integer"). ", ".
+                $ilDB->quote($sess_msg_concurrent, "text"). 
                 ")");
             } else {
                 $ilDB->manipulate(
@@ -152,7 +197,11 @@ class ilBigBlueButtonConfigGUI extends ilPluginConfigGUI
                 " svrpublicurl = ".$ilDB->quote($setPublicURL, "text").",".
                 " svrsalt = ".$ilDB->quote($setSalt, "text"). ",".
                 " choose_recording = ".$ilDB->quote($choose_recording, "integer"). ",".
-                "guestglobalchoose = ". $ilDB->quote($guest_global_choose, "integer").
+                "guestglobalchoose = ". $ilDB->quote($guest_global_choose, "integer"). ", ".
+                "sess_enable_max_concurrent = ". $ilDB->quote($sess_enable_max_concurrent, "integer"). ", ".
+                "enable_userlimit = ". $ilDB->quote($enable_userlimit, "integer"). ", ".
+                "sess_max_concurrent = ". $ilDB->quote($sess_max_concurrent, "integer"). ", ".
+                "sess_msg_concurrent = ". $ilDB->quote($sess_msg_concurrent, "text"). 
                 " WHERE id = ".$ilDB->quote(1, "integer")
                 );
             }

--- a/classes/class.ilBigBlueButtonProtocol.php
+++ b/classes/class.ilBigBlueButtonProtocol.php
@@ -27,11 +27,13 @@ class ilBigBlueButtonProtocol
     private $createMeetingParam;
     private $avatar;
     private $user;
+    private $meetings;
 
     public function __construct($object)
     {
         $this->object = $object;
         $this->bbb = new BBB($this->object->getSvrSalt(), $this->object->getSvrPublicURL());
+        $this->meetings = $this->bbb->getMeetings();
     }
     public function getAvatar()
     {
@@ -220,6 +222,37 @@ class ilBigBlueButtonProtocol
     private function isPDFValid(string $pdf){
         
         return filter_var($pdf, FILTER_VALIDATE_URL) ? true : false;
+    }
+
+    
+    public function getMaximumSessionsAvailable($meeting_id = null)
+    {
+        $participants_count = 0;
+        $sessions_available = array(
+            "current_meeting_userlimit" => false,
+            "max_sessions" => false,
+        );
+        $available = array();
+        foreach($this->meetings->getMeetings() as $meeting){
+            $participants_count = $participants_count + $meeting->getParticipantCount();
+            $userlimit_exceeded = ($meeting->getMaxUsers() - $meeting->getParticipantCount() -1 <= 0);
+               $available[$meeting->getMeetingId()] = [
+                
+                'participants' => $meeting->getParticipantCount(),
+                'max_users' => $meeting->getMaxUsers(),
+                'userlimit' => $userlimit_exceeded
+                
+            ];
+            if($meeting_id && $meeting->getMeetingId() == $meeting_id && $userlimit_exceeded){
+                $sessions_available['current_meeting_userlimit'] = true;
+            }
+        }
+        $sessions_available['meetings'] = $available;
+        if ($this->object->getMaxConcurrentSessions() > 0 && $participants_count >= $this->object->getMaxConcurrentSessions() - 1){
+            $sessions_available["max_sessions"] = true;
+        }
+        return $sessions_available;
+
     }
 }
 

--- a/classes/class.ilBigBlueButtonProtocol.php
+++ b/classes/class.ilBigBlueButtonProtocol.php
@@ -235,7 +235,7 @@ class ilBigBlueButtonProtocol
         $available = array();
         foreach($this->meetings->getMeetings() as $meeting){
             $participants_count = $participants_count + $meeting->getParticipantCount();
-            $userlimit_exceeded = ($meeting->getMaxUsers() - $meeting->getParticipantCount() -1 <= 0);
+            $userlimit_exceeded =( $this->object->getMaxParticipants() > 0 && ($meeting->getMaxUsers() - $meeting->getParticipantCount() -1 <= 0));
                $available[$meeting->getMeetingId()] = [
                 
                 'participants' => $meeting->getParticipantCount(),

--- a/classes/class.ilObjBigBlueButton.php
+++ b/classes/class.ilObjBigBlueButton.php
@@ -44,6 +44,10 @@ class ilObjBigBlueButton extends ilObjectPlugin
     private $refreshToken;
     private $publish = true;
     private $allow_download = false;
+    private $enable_userlimit = false;
+    private $enable_max_concurrent = false;
+    private $max_concurrent_sessions = 0;
+    private $max_concurrent_sessions_msg;
     /**
     * Constructor
     *
@@ -102,6 +106,10 @@ class ilObjBigBlueButton extends ilObjectPlugin
             $this->setSvrPublicURL($record["svrpublicurl"]);
             $this->setSvrSalt($record["svrsalt"]);
             $this->setGuestGlobalEnabled((bool)$record["guestglobalchoose"]);
+            $this->enableUserLimit((bool) $record['enable_userlimit']);
+            $this->enableMaxConcurrentSession((bool) $record['sess_enable_max_concurrent']);
+            $this->setMaxConcurrentSessions((int) $record['sess_max_concurrent']);
+            $this->setMaxConcurrentSessionsMsg($record['sess_msg_concurrent']);
         }
     }
 
@@ -138,6 +146,10 @@ class ilObjBigBlueButton extends ilObjectPlugin
             $this->setSvrPublicURL($record["svrpublicurl"]);
             $this->setSvrSalt($record["svrsalt"]);
             $this->setGuestGlobalEnabled((bool)$record["guestglobalchoose"]);
+            $this->enableUserLimit((bool) $record['enable_userlimit']);
+            $this->enableMaxConcurrentSession((bool) $record['sess_enable_max_concurrent']);
+            $this->setMaxConcurrentSessions((int) $record['sess_max_concurrent']);
+            $this->setMaxConcurrentSessionsMsg($record['sess_msg_concurrent']);
         }
     }
 
@@ -195,6 +207,10 @@ class ilObjBigBlueButton extends ilObjectPlugin
         $new_obj->setGuestLinkAllowed($this->isGuestLinkAllowed());
         $new_obj->setPublish($this->getPublish());
         $new_obj->setDownloadAllowed($this->isDownloadAllowed());
+        $new_obj->enableMaxConcurrentSession($this->isMaxConcurrentSessionEnabled());
+        $new_obj->enableUserLimit($this->isUserLimitEnabled());
+        $new_obj->setMaxConcurrentSession($this->getMaxConcurrentSessions());
+        $new_obj->setMaxConcurrentSessionsMsg($this->getMaxConcurrentSessionsMsg());
 
         $new_obj->update();
     }
@@ -399,6 +415,40 @@ class ilObjBigBlueButton extends ilObjectPlugin
     public function setDownloadAllowed($allow_download)
     {
         $this->allow_download = $allow_download;
+    }
+    public function isMaxConcurrentSessionEnabled()
+    {
+        return $this->enable_max_concurrent;
+
+    }
+    public function enableMaxConcurrentSession($enabled = false)
+    {
+        $this->enable_max_concurrent = $enabled;
+
+    }
+    public function getMaxConcurrentSessions()
+    {
+        return $this->max_concurrent_sessions;
+    }
+    public function setMaxConcurrentSessions($max_concurrent_sess = 0)
+    {
+        $this->max_concurrent_sessions = $max_concurrent_sess;
+    }
+    public function isUserLimitEnabled()
+    {
+        return $this->enable_userlimit;
+    }
+    public function enableUserLimit( $enabled = false)
+    {
+        $this->enable_userlimit = $enabled;
+    }
+    public function setMaxConcurrentSessionsMsg($message = "")
+    {
+        $this->max_concurrent_sessions_msg = $message;
+    }
+    public function getMaxConcurrentSessionsMsg()
+    {
+        return $this->max_concurrent_sessions_msg;
     }
 
 }

--- a/classes/class.ilObjBigBlueButtonGUI.php
+++ b/classes/class.ilObjBigBlueButtonGUI.php
@@ -312,6 +312,9 @@ class ilObjBigBlueButtonGUI extends ilObjectPluginGUI
         include_once("./Customizing/global/plugins/Services/Repository/RepositoryObject/BigBlueButton/classes/class.ilBigBlueButtonProtocol.php");
         $BBBHelper=new ilBigBlueButtonProtocol($this->object);
 
+        $available_sessions = $BBBHelper->getMaximumSessionsAvailable();
+        //$BBBHelper->getMeetings();
+
         if ($isModerator) {
             $my_tpl = new ilTemplate("./Customizing/global/plugins/Services/Repository/RepositoryObject/BigBlueButton/templates/tpl.BigBlueButtonModeratorClient.html", true, true);
 
@@ -356,6 +359,14 @@ class ilObjBigBlueButtonGUI extends ilObjectPluginGUI
             $my_tpl->setVariable("classNotStartedText", $this->txt("class_not_started_yet"));
 
             $bbbURL=$BBBHelper->joinURL($this->object);
+        }
+
+        $my_tpl->setVariable('isMaxNumberOfSessionsExceeded', 'false');
+        if($this->object->isMaxConcurrentSessionEnabled()){
+            if($available_sessions['max_sessions'] ||  (  key_exists($this->object->getBBBId(), $available_sessions['meetings']) && $available_sessions['meetings'][$this->object->getBBBId()]['userlimit'])){
+                $my_tpl->setVariable('isMaxNumberOfSessionsExceeded', 'true');
+                $my_tpl->setVariable('maxNumberofSessionsExceededText', $this->object->getMaxConcurrentSessionsMsg());
+            }
         }
 
         $my_tpl->setVariable("clickToOpenClass", $this->txt("click_to_open_class"));

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -70,6 +70,13 @@ guest_displayname_input#:#Geben Sie Ihren Namen ein!
 btntext_join_meeting#:#Meeting beitreten
 top_moderated_m#:#Willkommen im Meetingraum!<br/>&nbsp;<br/>Dies ist ein moderierter Raum und Sie können stets erst dann in den Meetingraum gelangen, wenn eine Person mit Moderatorfunktion im Raum ist.
 guest_invite_info#:#Mit dem folgenden Link k&ouml;nnen Sie G&auml;ste zum Meeting einladen:
+sess_max_concurrent_sessions#:#Begrenzte Anzahl gleichzeitiger Sitzungen
+sess_enable_userlimit#:#Benutzerlimit in den Sitzungseinstellungen festlegen
+sess_msg_userlimit#:# Die Anzahl der für eine Sitzung zulässigen Benutzer wurde erreicht.
+sess_msg_concurrent_limit#:#Die zulässige Anzahl der gleichzeitigen Sitzungen wurde überschritten 
+sess_msg_concurrent_limit_title#:#Error-Message
+sess_msg_concurrent_limit_info#:#Diese Textnachricht wird bei überschrittener Anzahl von Sitzungen angezeigt
+sess_management_header#:#Sitzungsmanagement (experimentell)
 dialnumber#:# Telefonnummer
 accesscode#:# Zugangscode
 guestchoose#:# Einladen von Gästen zulassen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -67,6 +67,13 @@ top_moderator#:#Welcome to the meeting room!<br/>&nbsp;<br/><b>This is a moderat
 guest_displayname_input#:#Enter your name!
 btntext_join_meeting#:#join meeting
 top_moderated_m#:#Welcome to the meeting room!<br/>&nbsp;<br/>This is a moderated room and you can always join the meeting room only when a moderator person is in the room.
+sess_max_concurrent_sessions#:#Limited number of concurrent sessions
+sess_enable_userlimit#:# Allow to set user limit in session settings
+sess_msg_userlimit#:#The number of users allowed per  session has been reached.
+sess_msg_concurrent_limit#:#The allowed number of simultaneous sessions was exceeded 
+sess_msg_concurrent_limit_title#:#Error message
+sess_msg_concurrent_limit_info#:#This text message is displayed when the number of sessions is exceeded
+sess_management_header#:#Session management (Experimental)
 dialnumber#:# phone number
 accesscode#:# access code
 guestchoose#:# Allow inviting guests

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
 $id = "xbbb";
  
 // code version; must be changed for all code changes
-$version = "2.0.1";
+$version = "2.0.2";
  
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -327,3 +327,36 @@ if ($ilDB->tableColumnExists("rep_robj_xbbb_conf", "svrprivateurl")){
 	$ilDB->dropTableColumn('rep_robj_xbbb_conf','svrprivateurl');	
 }
 ?>
+<#10>
+<?php
+if (!$ilDB->tableColumnExists("rep_robj_xbbb_conf", "sess_msg_concurrent")
+  && !$ilDB->tableColumnExists("rep_robj_xbbb_conf", "sess_max_concurrent")
+  && !$ilDB->tableColumnExists("rep_robj_xbbb_conf", "sess_enable_max_concurrent")
+  && !$ilDB->tableColumnExists("rep_robj_xbbb_conf", "enable_userlimit")
+){
+	$ilDB->addTableColumn('rep_robj_xbbb_conf','sess_enable_max_concurrent', array(
+		'type' => 'integer',
+		'length' => 2,
+		'notnull' => false,
+		'default' => 0
+	));
+	$ilDB->addTableColumn('rep_robj_xbbb_conf','enable_userlimit', array(
+		'type' => 'integer',
+		'length' => 2,
+		'notnull' => false,
+		'default' => 0
+	));
+	$ilDB->addTableColumn('rep_robj_xbbb_conf','sess_max_concurrent', array(
+		'type' => 'integer',
+		'length' => 2,
+		'notnull' => false,
+		'default' => 0
+	));
+	$ilDB->addTableColumn('rep_robj_xbbb_conf','sess_msg_concurrent', array(
+		'type' => 'text',
+		'length' => 1000,
+		'notnull' => false
+	));
+	
+}
+?>

--- a/templates/bbb.css
+++ b/templates/bbb.css
@@ -20,3 +20,9 @@
 .ilInfoScreenSec.form-horizontal.hide{
     display: none;
 }
+
+.bbb_error_msg{
+    padding-top: 10px;
+    color: red;
+    font-weight: 700;
+}

--- a/templates/tpl.BigBlueButtonClient.html
+++ b/templates/tpl.BigBlueButtonClient.html
@@ -8,7 +8,12 @@
 		{
                     
 			var isMeetingRunning={isMeetingRunning};
-			if(isMeetingRunning){
+			var isMaxNumberOfSessionsExceeded = {isMaxNumberOfSessionsExceeded};
+			if (isMaxNumberOfSessionsExceeded){
+				$('#openClassLink').hide();
+				$('#classNotStarted').hide();
+				$('#maxNumberofSessionsExceeded').show();
+			}else if(isMeetingRunning){
 				$('#openClassLink').show();
 				$('#classNotStarted').hide();
 			}else{
@@ -30,6 +35,9 @@
 
 <div id="classNotStarted">
 	{classNotStartedText}
+</div>
+<div class="bbb_error_msg" id="maxNumberofSessionsExceeded">
+	{maxNumberofSessionsExceededText}
 </div>
 <div id="isMeetingRecorded">{meetingRecordedMessage}</div>
 

--- a/templates/tpl.BigBlueButtonModeratorClient.html
+++ b/templates/tpl.BigBlueButtonModeratorClient.html
@@ -16,10 +16,15 @@
 
 			$('#endClassForm').hide();
 			$('#startClassForm').hide();
-                        $('#deleteRecording').hide();
+            $('#deleteRecording').hide();
+			$('#maxNumberofSessionsExceeded').hide();
 			
 			var isMeetingRunning={isMeetingRunning};
+			var isMaxNumberOfSessionsExceeded = {isMaxNumberOfSessionsExceeded};
 			if(isMeetingRunning){
+				if(isMaxNumberOfSessionsExceeded){
+					$('#maxNumberofSessionsExceeded').show();
+				}
 				$('#openClassLink').show();
 				$('#endClassDiv').show();
 				$('#startClassDiv').hide();
@@ -101,6 +106,9 @@
     <input id="startClassFormInput" class="submit" type="submit" name="{CMD_START_CLASS}" value="{START_CLASS}" >
     <input type="checkbox" id="recordmeeting" name="recordmeeting" />
 </form>
+<div class="bbb_error_msg" id="maxNumberofSessionsExceeded">
+	{maxNumberofSessionsExceededText}
+</div>
 
 <div class="ilInfoScreenSec form-horizontal {HIDE_GUESTLINK}" id="infoscreen_section_2">
     <h3 class="ilHeader">{GUEST_INVITE_INFO}&nbsp;</h3>

--- a/templates/tpl.guest.html
+++ b/templates/tpl.guest.html
@@ -9,6 +9,7 @@
     <h1>{MEETING_TITLE}</h1>
     <div id="info_top">{INFO_TOP_MODERATED_M}</div>
     <div id="err_messages" class="messages">
+        <div class="err_userlimit_{ERR_STATE_USER_LIMIT} alert alert-danger">{ERR_MSG_USER_LIMIT}</div>
         <div class="err_displayname_{ERR_STATE_INPUT_FIELD} alert alert-danger">{ERR_MSG_INPUT_FIELD}</div>
         <div class="err_moderator_{ERR_STATE_MODERATOR} alert alert-info">{ERR_MSG_MODERATOR}</div>
     </div>
@@ -84,7 +85,8 @@
     }
     .err_displayname_1,
     .err_termsofuse_1,
-    .err_moderator_1 {
+    .err_moderator_1,
+    .err_userlimit_1 {
         display: block;
         width: 67%;
         margin: auto;


### PR DESCRIPTION
this PR implements   a feature that gives  the user the info that if no more server licenses/sessions are available, that the room cannot start because of that. The text that appears is configurable in the plugin.

Example/Background: some BBB-Plugin users use the provider bbbserver.de, and it allows us to run 99 connections in parallel via the plugin. Each conference books itself 25 licenses, so you can open 4 in parallel.
The requirement was whether  this number of licenses could be configured by the moderator when starting the room.