### PR TITLE
bigbluebutton failure in update because of incompatibleclass methode …

### DIFF
--- a/guest.php
+++ b/guest.php
@@ -63,11 +63,11 @@ class ilInitialisationGuest extends ilInitialisation
      * Function; initGlobal($a_name, $a_class, $a_source_file)
      *  Derive from protected to public...
      *
-     * @see \ilInitialisation::initGlobal($a_name, $a_class, $a_source_file)
+     * @see \ilInitialisation::initGlobal($a_name, $a_class, $a_source_file, $destroy_existing)
      */
-    public static function initGlobal($a_name, $a_class, $a_source_file = null): void
+    public static function initGlobal($a_name, $a_class, $a_source_file = null, ?bool $destroy_existing = false): void
     {
-        parent::initGlobal($a_name, $a_class, $a_source_file);
+        parent::initGlobal($a_name, $a_class, $a_source_file, $destroy_existing);
     }
 
     /**


### PR DESCRIPTION
bigbluebutton failure in ilias 8 update because of incompatible class methode "initGlobal" with standard
this is the customization for standard