### PR TITLE
0044179: Fix: handle error caused by trimming nullable welcome message

### DIFF
--- a/vendor/bigbluebutton/bigbluebutton-api-php/src/Parameters/CreateMeetingParameters.php
+++ b/vendor/bigbluebutton/bigbluebutton-api-php/src/Parameters/CreateMeetingParameters.php
@@ -1392,7 +1392,7 @@ class CreateMeetingParameters extends MetaParameters
             'maxParticipants'                        => $this->maxParticipants,
             'autoStartRecording'                     => !is_null($this->autoStartRecording) ? ($this->autoStartRecording ? 'true' : 'false') : $this->autoStartRecording,
             'allowStartStopRecording'                => !is_null($this->allowStartStopRecording) ? ($this->allowStartStopRecording ? 'true' : 'false') : $this->allowStartStopRecording,
-            'welcome'                                => trim($this->welcomeMessage),
+            'welcome'                                => trim($this->welcomeMessage ?? ''),
             'moderatorOnlyMessage'                   => trim($this->moderatorOnlyMessage),
             'webcamsOnlyForModerator'                => !is_null($this->webcamsOnlyForModerator) ? ($this->webcamsOnlyForModerator ? 'true' : 'false') : $this->webcamsOnlyForModerator,
             'logo'                                   => $this->logo,


### PR DESCRIPTION
**Mantis issue:** https://mantis.ilias.de/view.php?id=44179

---

**Problem**

A fatal exception occurs when no welcome message is defined for a new BBB room.

<img width="800" height="419" alt="image" src="https://github.com/user-attachments/assets/b22bb82c-f107-432f-83e5-6b63c86b5402" />

---

**Solution**

Provide an empty string as a default value for welcomeMessage in case of not provided.
